### PR TITLE
feature (tf): Updating s3_log_storage module version

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -5,7 +5,7 @@ locals {
 
 module "ssm-bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.28.0"
+  version = "0.28.1"
 
   namespace   = module.label.namespace
   environment = module.label.environment


### PR DESCRIPTION
# Description
This change updates the version of s3_log_storage module. Updated module is fixing the issue with inability to use `var.privileged_principal_arns` calculated during the same run in `count` condition.

`Error: Invalid count argument
│
│   on .terraform/modules/ssm_session_log.ssm-bucket.aws_s3_bucket/main.tf line 447, in resource "aws_s3_bucket_policy" "default":
│  447:   count      = local.enabled && (var.allow_ssl_requests_only || var.allow_encrypted_uploads_only || length(var.s3_replication_source_roles) > 0 || length(var.privileged_principal_arns) > 0 || var.policy != "") ? 1 : 0`

Related aws provider [issue](https://github.com/hashicorp/terraform-provider-aws/issues/27386) 
